### PR TITLE
Speed up health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,6 @@ WORKDIR $USER_HOME
 EXPOSE $APP_PORT
 # to view healthcheck status:
 # docker inspect --format "{{json .State.Health }}" <container name> | jq
-HEALTHCHECK --interval=30s --start-period=45s --start-interval=1s --timeout=10s CMD curl --fail http://localhost:$APP_PORT/ping || exit 1
+HEALTHCHECK --interval=30s --start-period=5s --start-interval=1s --timeout=10s CMD curl --fail http://localhost:$APP_PORT/ping || exit 1
 
 CMD uvicorn --app-dir $APP_DIR main:app --host $APP_HOST --port $APP_PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,6 @@ WORKDIR $USER_HOME
 EXPOSE $APP_PORT
 # to view healthcheck status:
 # docker inspect --format "{{json .State.Health }}" <container name> | jq
-HEALTHCHECK --interval=30s --timeout=10s CMD curl --fail http://localhost:$APP_PORT/ping || exit 1
+HEALTHCHECK --interval=30s --start-period=45s --start-interval=1s --timeout=10s CMD curl --fail http://localhost:$APP_PORT/ping || exit 1
 
 CMD uvicorn --app-dir $APP_DIR main:app --host $APP_HOST --port $APP_PORT


### PR DESCRIPTION
Any software that waits for the container to be healthy when starting this container will take at least 30 seconds due to the configured interval.

This adds a start-period of 5 seconds and a start interval of 1s to make the service healthy almost immediately.

Note that this requires Docker Engine 25+

> **start period** provides initialization time for containers that need time to bootstrap. Probe failure during that period will not be counted towards the maximum number of retries. However, if a health check succeeds during the start period, the container is considered started and all consecutive failures will be counted towards the maximum number of retries.

> **start interval** is the time between health checks during the start period. This option requires Docker Engine version 25.0 or later.

Ref: https://docs.docker.com/reference/dockerfile/#healthcheck